### PR TITLE
Removing Seabird from direct dependency.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,4 @@ netCDF4>=1.1.8
 pyproj>=1.9.4
 matplotlib>=1.4.0
 wodpy>=1.0.0
-seabird>=0.6.3
 cotede>=0.14.1


### PR DESCRIPTION
If AutoQC is not directly using the seabird package, let's leave only
cotede as a dependency. When installing cotede, pip will automatically
install seabird. In the near future I'll transform seabird into an
optional dependency, and AutoQC would be able to reduce it's
requirements.
