### PR TITLE
Adding optional dependecies to allow more tests in CoTeDe.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,7 @@ matplotlib>=1.4.0
 wodpy>=1.0.0
 seabird>=0.6.3
 cotede>=0.14.1
+netCDF4
+gsw
+scikit-fuzzy
+pyWOA


### PR DESCRIPTION
These package are optional dependencies of CoTeDe, but AutoQC would need to install it to access full CoTeDe resources.
