### PR TITLE
Locking cotede

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ netCDF4>=1.1.8
 pyproj>=1.9.4
 matplotlib>=1.4.0
 wodpy>=1.0.0
-cotede>=0.14.1
+cotede==0.15.3
 netCDF4
 gsw
 scikit-fuzzy

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ pyproj>=1.9.4
 matplotlib>=1.4.0
 wodpy>=1.0.0
 cotede==0.15.3
-netCDF4
 gsw
 scikit-fuzzy
 pyWOA


### PR DESCRIPTION
Might be a good idea to lock CoTeDe version on AutoQC to minimize problems on the AWS/Docker development. On this way I would update CoTeDe version on requirements.txt only after I already tested everything with AutoQC.

Right now Bill might be having problems since the CoTeDe version in Pypi (updated) is incompatible with the consistency checks in the official (main branch) AutoQC.
